### PR TITLE
native-hdr-histogram: upgrade due to node >=10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dataloader": "^1.2.0",
     "make-error": "^1.2.1",
     "measured": "^1.1.0",
-    "native-hdr-histogram": "^0.4.4",
+    "native-hdr-histogram": "^0.7.0",
     "lodash": "^4.16.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Why this PR is necessary?**

The current version of `native-hdr-histogram` used by this package does not support installation in node >= 10. This update provides newer versions of node to install `node-finagle`